### PR TITLE
fix: use RELEASE_PLEASE_TOKEN in releasing workflow

### DIFF
--- a/.github/workflows/releasing.yaml
+++ b/.github/workflows/releasing.yaml
@@ -14,7 +14,7 @@ jobs:
   create-release:
     runs-on: ubuntu-latest
     env:
-      GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
+      GITHUB_TOKEN: "${{ secrets.RELEASE_PLEASE_TOKEN }}"
       GITHUB_BRANCH: "main"
     steps:
       - uses: googleapis/release-please-action@v4


### PR DESCRIPTION
This will allow to trigger checks in the release pull request